### PR TITLE
Return correct object type from Lumina

### DIFF
--- a/src/XIVAPI.KR/Controllers/Item/ItemController.cs
+++ b/src/XIVAPI.KR/Controllers/Item/ItemController.cs
@@ -22,7 +22,7 @@ namespace XIVAPI.KR.Controllers.Item
         {
             try
             {
-                return Ok(_lumina.GetItems());
+                return Ok(_lumina.GetItems().Values);
             }
             catch (Exception)
             {


### PR DESCRIPTION
`_lumina.GetItems()` returns `IReadOnlyDictionary<int,ItemDto>`, but the expected return type is `IEnumerable<ItemDto>`.